### PR TITLE
Auto-dismiss area detail alerts

### DIFF
--- a/area-details.php
+++ b/area-details.php
@@ -316,12 +316,12 @@ require_once __DIR__ . '/includes/common-header.php';
             <!-- Dashboard Content -->
             <div class="p-2">
                 <?php if ($successMessage): ?>
-                    <div class="alert alert-success alert-dismissible fade show" role="alert">
+                    <div class="alert alert-success alert-dismissible fade show" role="alert" data-auto-dismiss="5000">
                         <?php echo htmlspecialchars($successMessage, ENT_QUOTES, 'UTF-8'); ?>
                         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                     </div>
                 <?php elseif ($errorMessage): ?>
-                    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                    <div class="alert alert-danger alert-dismissible fade show" role="alert" data-auto-dismiss="5000">
                         <?php echo htmlspecialchars($errorMessage, ENT_QUOTES, 'UTF-8'); ?>
                         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                     </div>

--- a/includes/common-footer.php
+++ b/includes/common-footer.php
@@ -155,6 +155,35 @@
   });
 </script>
 
+<script>
+    // Auto-dismiss alerts that opt-in via data-auto-dismiss attribute
+    (function () {
+        const alerts = document.querySelectorAll('.alert[data-auto-dismiss]');
+        if (!alerts.length) {
+            return;
+        }
+
+        alerts.forEach((alertEl) => {
+            const attributeValue = alertEl.getAttribute('data-auto-dismiss');
+            let delay = parseInt(attributeValue, 10);
+            if (Number.isNaN(delay) || delay < 0) {
+                delay = 5000;
+            }
+
+            window.setTimeout(() => {
+                if (window.bootstrap && typeof window.bootstrap.Alert === 'function') {
+                    const instance = window.bootstrap.Alert.getOrCreateInstance(alertEl);
+                    instance.close();
+                    return;
+                }
+
+                alertEl.classList.remove('show');
+                alertEl.style.display = 'none';
+            }, delay);
+        });
+    })();
+</script>
+
 
 
 </body>


### PR DESCRIPTION
## Summary
- mark success and error alerts on the area details form for automatic dismissal
- add a shared script that hides any alert opting in via `data-auto-dismiss` after the requested delay

## Testing
- php -l area-details.php
- php -l includes/common-footer.php

------
https://chatgpt.com/codex/tasks/task_e_68c94d224c88832a8f25ac9b74429b43