### PR TITLE
Include media assets in area detail PDF

### DIFF
--- a/pdfhtml/index.php
+++ b/pdfhtml/index.php
@@ -1,6 +1,7 @@
 <?php
 $report = $report ?? [];
 $amenities = $report['amenities'] ?? [];
+$filesByKey = $filesByKey ?? [];
 $displayValue = static function (?string $value, string $fallback = 'N/A'): string {
     $value = trim((string) ($value ?? ''));
     return $value === '' ? htmlspecialchars($fallback, ENT_QUOTES, 'UTF-8') : htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
@@ -16,6 +17,101 @@ $formatParagraph = static function (?string $value): string {
 
     return nl2br(htmlspecialchars($value, ENT_QUOTES, 'UTF-8'), false);
 };
+$displayParagraph = static function (?string $value, string $fallback = 'N/A') use ($formatParagraph): string {
+    $formatted = $formatParagraph($value);
+    if ($formatted === '') {
+        return '<span class="muted">' . htmlspecialchars($fallback, ENT_QUOTES, 'UTF-8') . '</span>';
+    }
+
+    return $formatted;
+};
+$formatFileSize = static function (?int $bytes): string {
+    if ($bytes === null || $bytes <= 0) {
+        return '';
+    }
+
+    $size = (float) $bytes;
+    $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    $index = 0;
+
+    while ($size >= 1024 && $index < count($units) - 1) {
+        $size /= 1024;
+        $index++;
+    }
+
+    $precision = ($size >= 10 || $index === 0) ? 0 : 1;
+
+    return number_format($size, $precision) . ' ' . $units[$index];
+};
+
+$fileDisplayMap = [
+    'banner_image' => 'Banner Image',
+    'area_image' => 'Area Image',
+    'project_image_2' => 'Project Image',
+    'transactions_image' => 'Transactions Image',
+    'property_images' => 'Property Gallery',
+    'floor_plan_file' => 'Floor Plans',
+];
+
+if ($filesByKey) {
+    foreach ($filesByKey as $key => $_) {
+        if (!array_key_exists($key, $fileDisplayMap)) {
+            $fileDisplayMap[$key] = ucwords(str_replace(['_', '-'], ' ', (string) $key));
+        }
+    }
+}
+
+$mediaGroups = [];
+foreach ($fileDisplayMap as $fileKey => $label) {
+    $items = $filesByKey[$fileKey] ?? [];
+    if (empty($items)) {
+        continue;
+    }
+
+    $group = [
+        'label' => $label,
+        'images' => [],
+        'files' => [],
+    ];
+
+    foreach ($items as $item) {
+        if (!is_array($item)) {
+            continue;
+        }
+
+        $isImage = !empty($item['is_image']);
+        if ($isImage) {
+            $group['images'][] = $item;
+        } else {
+            $group['files'][] = $item;
+        }
+    }
+
+    if ($group['images'] || $group['files']) {
+        $mediaGroups[] = $group;
+    }
+}
+
+$hasMediaGroups = !empty($mediaGroups);
+
+$coverImage = null;
+if (!empty($filesByKey['banner_image'])) {
+    foreach ($filesByKey['banner_image'] as $bannerFile) {
+        if (!empty($bannerFile['is_image'])) {
+            $coverImage = $bannerFile;
+            break;
+        }
+    }
+}
+
+if ($coverImage === null && !empty($filesByKey['area_image'])) {
+    foreach ($filesByKey['area_image'] as $areaFile) {
+        if (!empty($areaFile['is_image'])) {
+            $coverImage = $areaFile;
+            break;
+        }
+    }
+}
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -36,7 +132,7 @@ $formatParagraph = static function (?string $value): string {
             padding: 0;
         }
 
-        .cover {
+        .cover {            
             height: 100vh;
             display: flex;
             align-items: center;
@@ -71,6 +167,20 @@ $formatParagraph = static function (?string $value): string {
         .cover p {
             margin: 5px 0;
             font-size: 14px;
+        }
+
+        .cover-image {
+            margin-top: 25px;
+            border: 1px solid rgba(255, 255, 255, 0.3);
+            border-radius: 12px;
+            overflow: hidden;
+            box-shadow: 0 12px 30px rgba(0, 0, 0, 0.25);
+        }
+
+        .cover-image img {
+            display: block;
+            width: 100%;
+            height: auto;
         }
 
         .page-break {
@@ -170,6 +280,61 @@ $formatParagraph = static function (?string $value): string {
             color: #6c7a89;
             text-align: right;
         }
+
+        .media-section {
+            margin-top: 10px;
+        }
+
+        .media-group {
+            margin-bottom: 25px;
+        }
+
+        .media-group h3 {
+            font-size: 15px;
+            margin: 0 0 10px;
+            color: #0f5c7c;
+        }
+
+        .media-gallery {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 15px;
+        }
+
+        .media-item {
+            width: calc(50% - 8px);
+            border: 1px solid #d9e1e7;
+            border-radius: 8px;
+            overflow: hidden;
+            background: #fff;
+            page-break-inside: avoid;
+        }
+
+        .media-item img {
+            display: block;
+            width: 100%;
+            height: auto;
+        }
+
+        .media-item figcaption {
+            padding: 8px 10px;
+            font-size: 11px;
+            color: #1f2a36;
+        }
+
+        .file-list {
+            margin: 0;
+            padding-left: 18px;
+        }
+
+        .file-list li {
+            margin: 4px 0;
+            font-size: 12px;
+        }
+
+        .file-list strong {
+            color: #0f5c7c;
+        }
     </style>
 </head>
 
@@ -179,7 +344,7 @@ $formatParagraph = static function (?string $value): string {
             <span class="cover-label">Area Detail Report</span>
             <h1><?= $displayValue($report['property_name'] ?? null, 'Area Detail') ?></h1>
             <?php if ($hasValue($report['address'] ?? null)): ?>
-                <p><?= $displayValue($report['address'] ?? null) ?></p>
+                <p><?= $displayParagraph($report['address'] ?? null) ?></p>
             <?php endif; ?>
             <?php if ($hasValue($report['developer_name'] ?? null)): ?>
                 <p>Developed by <?= $displayValue($report['developer_name'] ?? null) ?></p>
@@ -188,6 +353,11 @@ $formatParagraph = static function (?string $value): string {
                 <p class="muted">Project: <?= $displayValue($report['project_name'] ?? null) ?></p>
             <?php endif; ?>
             <p class="muted">Generated on <?= $displayValue($report['generated_at'] ?? null, date('F j, Y g:i A')) ?></p>
+            <?php if ($coverImage !== null && !empty($coverImage['data_uri'])): ?>
+                <div class="cover-image">
+                    <img src="<?= htmlspecialchars($coverImage['data_uri'], ENT_QUOTES, 'UTF-8') ?>" alt="<?= htmlspecialchars($coverImage['name'] !== '' ? $coverImage['name'] : 'Cover Image', ENT_QUOTES, 'UTF-8') ?>">
+                </div>
+            <?php endif; ?>
         </div>
     </div>
 
@@ -199,6 +369,10 @@ $formatParagraph = static function (?string $value): string {
             <tr>
                 <th>Property Name</th>
                 <td><?= $displayValue($report['property_name'] ?? null) ?></td>
+            </tr>
+            <tr>
+                <th>Address</th>
+                <td><?= $displayParagraph($report['address'] ?? null) ?></td>
             </tr>
             <tr>
                 <th>Property ID</th>
@@ -278,7 +452,7 @@ $formatParagraph = static function (?string $value): string {
                     </tr>
                     <tr>
                         <th>Payment Plan</th>
-                        <td><?= $displayValue($report['payment_plan'] ?? null) ?></td>
+                        <td><?= $displayParagraph($report['payment_plan'] ?? null) ?></td>
                     </tr>
                 </table>
             </div>
@@ -286,15 +460,15 @@ $formatParagraph = static function (?string $value): string {
                 <table class="info-table">
                     <tr>
                         <th>Down Payment</th>
-                        <td><?= $displayValue($report['down_payment'] ?? null) ?></td>
+                        <td><?= $displayParagraph($report['down_payment'] ?? null) ?></td>
                     </tr>
                     <tr>
                         <th>Pre-handover</th>
-                        <td><?= $displayValue($report['pre_handover'] ?? null) ?></td>
+                        <td><?= $displayParagraph($report['pre_handover'] ?? null) ?></td>
                     </tr>
                     <tr>
                         <th>On Handover</th>
-                        <td><?= $displayValue($report['handover'] ?? null) ?></td>
+                        <td><?= $displayParagraph($report['handover'] ?? null) ?></td>
                     </tr>
                 </table>
             </div>
@@ -325,9 +499,64 @@ $formatParagraph = static function (?string $value): string {
                 </tr>
                 <tr>
                     <th>Project Narrative</th>
-                    <td><?= $displayValue($report['project_description_2'] ?? null) ?></td>
+                    <td><?= $displayParagraph($report['project_description_2'] ?? null) ?></td>
                 </tr>
             </table>
+        <?php endif; ?>
+
+        <?php if ($hasMediaGroups): ?>
+            <div class="page-break"></div>
+            <div class="page media-section">
+                <h2 class="section-title">Media &amp; Attachments</h2>
+                <?php foreach ($mediaGroups as $group): ?>
+                    <div class="media-group">
+                        <h3><?= htmlspecialchars($group['label'], ENT_QUOTES, 'UTF-8') ?></h3>
+                        <?php if (!empty($group['images'])): ?>
+                            <div class="media-gallery">
+                                <?php foreach ($group['images'] as $index => $image): ?>
+                                    <figure class="media-item">
+                                        <img src="<?= htmlspecialchars($image['data_uri'], ENT_QUOTES, 'UTF-8') ?>" alt="<?= htmlspecialchars(($image['name'] ?? '') !== '' ? $image['name'] : ($group['label'] . ' ' . ($index + 1)), ENT_QUOTES, 'UTF-8') ?>">
+                                        <figcaption>
+                                            <?php if (!empty($image['name'])): ?>
+                                                <strong><?= htmlspecialchars($image['name'], ENT_QUOTES, 'UTF-8') ?></strong>
+                                            <?php else: ?>
+                                                <strong><?= htmlspecialchars($group['label'], ENT_QUOTES, 'UTF-8') ?></strong>
+                                            <?php endif; ?>
+                                            <?php $sizeLabel = $formatFileSize(isset($image['size']) ? (int) $image['size'] : null); ?>
+                                            <?php if ($sizeLabel !== ''): ?>
+                                                <br><span class="muted">Size: <?= htmlspecialchars($sizeLabel, ENT_QUOTES, 'UTF-8') ?></span>
+                                            <?php endif; ?>
+                                            <?php if (!empty($image['created_at'])): ?>
+                                                <br><span class="muted">Uploaded: <?= htmlspecialchars($image['created_at'], ENT_QUOTES, 'UTF-8') ?></span>
+                                            <?php endif; ?>
+                                        </figcaption>
+                                    </figure>
+                                <?php endforeach; ?>
+                            </div>
+                        <?php endif; ?>
+
+                        <?php if (!empty($group['files'])): ?>
+                            <ul class="file-list">
+                                <?php foreach ($group['files'] as $file): ?>
+                                    <li>
+                                        <strong><?= htmlspecialchars(!empty($file['name']) ? $file['name'] : $group['label'], ENT_QUOTES, 'UTF-8') ?></strong>
+                                        <?php $sizeLabel = $formatFileSize(isset($file['size']) ? (int) $file['size'] : null); ?>
+                                        <?php if ($sizeLabel !== ''): ?>
+                                            <span class="muted">(<?= htmlspecialchars($sizeLabel, ENT_QUOTES, 'UTF-8') ?>)</span>
+                                        <?php endif; ?>
+                                        <?php if (!empty($file['mime'])): ?>
+                                            <br><span class="muted">Type: <?= htmlspecialchars($file['mime'], ENT_QUOTES, 'UTF-8') ?></span>
+                                        <?php endif; ?>
+                                        <?php if (!empty($file['created_at'])): ?>
+                                            <br><span class="muted">Uploaded: <?= htmlspecialchars($file['created_at'], ENT_QUOTES, 'UTF-8') ?></span>
+                                        <?php endif; ?>
+                                    </li>
+                                <?php endforeach; ?>
+                            </ul>
+                        <?php endif; ?>
+                    </div>
+                <?php endforeach; ?>
+            </div>
         <?php endif; ?>
 
         <div class="footer">


### PR DESCRIPTION
## Summary
- load associated area_detail_files records when building the PDF payload so uploaded assets are available to the template
- enhance the PDF template to show property addresses with preserved formatting and to render payment plan style fields with line breaks
- add a dedicated media & attachments section that embeds uploaded images and lists any non-image files, including a banner image on the cover page

## Testing
- php -l download-area-detail.php
- php -l pdfhtml/index.php

------
https://chatgpt.com/codex/tasks/task_e_68ca451030ec832a85ef8e5b05ae91b2